### PR TITLE
sqldef でマイグレーションを実現する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .env
 .DS_Store
 node_modules/
+psqldef

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,0 +1,9 @@
+# migration
+
+## dry run
+
+`./psqldef -h localhost -U postgres tocre --dry-run < schema.sql`
+
+## run
+
+`./psqldef -h localhost -U postgres tocre < schema.sql`

--- a/schema/README.md
+++ b/schema/README.md
@@ -1,5 +1,22 @@
 # migration
 
+migration には sqldef を用います
+https://github.com/k0kubun/sqldef
+
+## Installation
+
+https://github.com/k0kubun/sqldef/releases
+
+のページから対応する psqldef をインストールします。
+
+|チップ|ダウンロードリンク|
+|Mac Intel|[psqldef_darwin_amd64.zip](https://github.com/k0kubun/sqldef/releases/download/v0.11.60/psqldef_darwin_amd64.zip)|
+|Mac M1|[psqldef_darwin_arm64.zip](https://github.com/k0kubun/sqldef/releases/download/v0.11.60/psqldef_darwin_arm64.zip)|
+
+ダウンロードした zip ファイルを解凍してこの schema ディレクトリに配置します。
+
+# Run
+
 ## dry run
 
 `./psqldef -h localhost -U postgres tocre --dry-run < schema.sql`

--- a/schema/schema.sql
+++ b/schema/schema.sql
@@ -1,0 +1,8 @@
+CREATE TABLE users (
+  id SERIAL NOT NULL,
+  firebase_uuid VARCHAR(255) NOT NULL UNIQUE,
+  name VARCHAR(255) NOT NULL,
+  created_at TIMESTAMP WITH TIME ZONE NOT NULL default current_timestamp,
+  updated_at TIMESTAMP WITH TIME ZONE NOT NULL default current_timestamp,
+  PRIMARY KEY (id)
+);


### PR DESCRIPTION

# 概要

データベースの形態は要件によって日々変化します。

データベースのスキーマの追加/削除やそのデータの調整等の動きのことを**マイグレーション**といいます

マイグレーション作業を一回一回手作業でやるのは大変なのでマイグレーションが簡単にできるようにしましょう。

マイグレーションを楽にするツールとしてsqldef を利用します。

sqldefは定義されたテーブル定義のSQL(今回はschema.sql)からマイグレーションを行ってくれます。


# 手順

以下の手順で実行できるか試してみてください

0. postgres db を起動しておく（`brew services start postgresql`
1. git switch feat/migration-psql でこのブランチに移動
2. psqldef をインストール（詳しくは /schema/readmeに記載しました）
3. ダウンロードした zip ファイルを解凍して、psql ファイルが生成されるので schema ディレクトリに配置。
4. ./psqldef -h localhost -U postgres tocre < schema.sql　を実行してユーザーテーブルが変化するか確認